### PR TITLE
feat: add o3-pro model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Tasks
+
+### Running the Server
+
+**Docker Setup (Recommended):**
+
+```bash
+# Initial setup - builds images, creates .env, starts services
+./setup-docker.sh
+
+# Start services
+docker compose up -d
+
+# Stop services
+docker compose down
+
+# View logs
+docker compose logs -f
+
+# Restart services
+docker compose restart
+```
+
+**Manual Setup:**
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Set environment variables
+export GEMINI_API_KEY=your-gemini-api-key
+export OPENAI_API_KEY=your-openai-api-key  # Optional
+
+# Run server
+python server.py
+```
+
+### Testing
+
+```bash
+# Run unit tests (no API key required)
+python -m pytest tests/ -v
+
+# Run with coverage
+python -m pytest tests/ --cov=. --cov-report=html
+
+# Run simulation tests (requires API keys)
+python communication_simulator_test.py
+
+# Run specific simulation tests
+python communication_simulator_test.py --tests basic_conversation
+
+# List available simulation tests
+python communication_simulator_test.py --list-tests
+```
+
+### Linting and Code Quality
+
+```bash
+# Format code with Black
+black .
+
+# Run linting
+ruff check .
+
+# Type checking
+mypy .
+```
+
+## Architecture Overview
+
+### Core Components
+
+**MCP Server (`server.py`)**:
+
+- Main entry point implementing the Model Context Protocol
+- Handles tool discovery and request routing
+- Manages communication via stdio JSON-RPC
+
+**Provider System (`providers/`)**:
+
+- Modular AI provider architecture supporting multiple models
+- `base.py`: Abstract base class defining provider interface
+- `gemini.py`: Google Gemini integration (Pro, Flash)
+- `openai.py`: OpenAI integration (O3, O3-mini, O3-pro)
+- `registry.py`: Dynamic provider registration and model selection
+
+**Tool System (`tools/`)**:
+
+- Each tool inherits from `BaseTool` and implements specific AI capabilities
+- Tools: `chat`, `thinkdeep`, `codereview`, `precommit`, `debug`, `analyze`
+- Auto mode intelligently selects the best model for each task
+
+**Conversation Memory (`utils/conversation_memory.py`)**:
+
+- Redis-backed conversation threading system
+- Enables multi-turn AI-to-AI conversations
+- Supports cross-tool continuation with shared context
+
+**Configuration (`config.py`)**:
+
+- Centralized configuration management
+- Environment variable handling
+- Model selection and defaults
+
+### Key Design Patterns
+
+1. **Provider Abstraction**: All AI providers implement a common interface, allowing easy addition of new models
+
+2. **Tool Modularity**: Each tool is self-contained with its own system prompt and processing logic
+
+3. **Incremental Context**: Conversations share only new information in each exchange to bypass MCP's 25K token limits
+
+4. **Auto Mode**: When `DEFAULT_MODEL=auto`, the server analyzes each request to select the optimal model
+
+5. **Docker-First**: Primary deployment via Docker Compose with Redis for production-ready setup
+
+### Adding New Features
+
+**To add a new AI provider:**
+
+1. Create new file in `providers/` implementing `BaseProvider`
+2. Register in `providers/registry.py`
+3. Add API key handling in `config.py`
+
+**To add a new tool:**
+
+1. Create new file in `tools/` inheriting from `BaseTool`
+2. Define system prompt in `prompts/tool_prompts.py`
+3. Import and register in `server.py`
+
+**To modify tool behavior:**
+
+- Edit prompts in `prompts/tool_prompts.py`
+- Adjust temperature settings in tool implementation
+- Override `get_system_prompt()` for tool-specific changes

--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
 | **`flash`** (Gemini 2.0 Flash) | Google | 1M tokens | Ultra-fast responses | Quick checks, formatting, simple analysis |
 | **`o3`** | OpenAI | 200K tokens | Strong logical reasoning | Debugging logic errors, systematic analysis |
 | **`o3-mini`** | OpenAI | 200K tokens | Balanced speed/quality | Moderate complexity tasks |
+| **`o3-pro`** | OpenAI | 200K tokens | Maximum reasoning depth for hardest problems | Multi-step reasoning, complex logic puzzles, toughest challenges |
 
 **Manual Model Selection:**
 You can specify a default model instead of auto mode:
@@ -949,4 +950,4 @@ Built with the power of **Multi-Model AI** collaboration 🤝
 - [MCP (Model Context Protocol)](https://modelcontextprotocol.com) by Anthropic
 - [Claude Code](https://claude.ai/code) - Your AI coding assistant & orchestrator
 - [Gemini 2.5 Pro & 2.0 Flash](https://ai.google.dev/) - Extended thinking & fast analysis
-- [OpenAI O3](https://openai.com/) - Strong reasoning & general intelligence
+- [OpenAI O3, O3-mini & O3-pro](https://openai.com/) - Strong reasoning & general intelligence

--- a/config.py
+++ b/config.py
@@ -26,7 +26,7 @@ DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "auto")
 
 # Validate DEFAULT_MODEL and set to "auto" if invalid
 # Only include actually supported models from providers
-VALID_MODELS = ["auto", "flash", "pro", "o3", "o3-mini", "gemini-2.0-flash", "gemini-2.5-pro-preview-06-05"]
+VALID_MODELS = ["auto", "flash", "pro", "o3", "o3-mini", "o3-pro", "gemini-2.0-flash", "gemini-2.5-pro-preview-06-05"]
 if DEFAULT_MODEL not in VALID_MODELS:
     import logging
 
@@ -46,6 +46,7 @@ MODEL_CAPABILITIES_DESC = {
     "pro": "Deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",
     "o3": "Strong reasoning (200K context) - Logical problems, code generation, systematic analysis",
     "o3-mini": "Fast O3 variant (200K context) - Balanced performance/speed, moderate complexity",
+    "o3-pro": "Maximum reasoning depth (200K context) - Hardest problems, multi-step reasoning, complex logic puzzles",
     # Full model names also supported
     "gemini-2.0-flash": "Ultra-fast (1M context) - Quick analysis, simple queries, rapid iterations",
     "gemini-2.5-pro-preview-06-05": "Deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",

--- a/providers/openai.py
+++ b/providers/openai.py
@@ -28,6 +28,10 @@ class OpenAIModelProvider(ModelProvider):
             "max_tokens": 200_000,  # 200K tokens
             "supports_extended_thinking": False,
         },
+        "o3-pro": {
+            "max_tokens": 200_000,  # 200K tokens
+            "supports_extended_thinking": False,
+        },
     }
 
     def __init__(self, api_key: str, **kwargs):
@@ -58,7 +62,7 @@ class OpenAIModelProvider(ModelProvider):
         config = self.SUPPORTED_MODELS[model_name]
 
         # Define temperature constraints per model
-        if model_name in ["o3", "o3-mini"]:
+        if model_name in ["o3", "o3-mini", "o3-pro"]:
             # O3 models only support temperature=1.0
             temp_constraint = FixedTemperatureConstraint(1.0)
         else:


### PR DESCRIPTION
## Summary
- Added support for OpenAI's o3-pro model to the Zen MCP Server
- o3-pro offers maximum reasoning depth for the hardest problems
- Includes proper configuration, validation, and documentation

## Changes
- **OpenAI Provider**: Added o3-pro to supported models with 200K token context
- **Configuration**: Added o3-pro to valid models and capability descriptions
- **Documentation**: Updated README with o3-pro capabilities and use cases
- **CLAUDE.md**: Added comprehensive development guide for future Claude Code instances

## Test plan
- [ ] Verify o3-pro model is recognized by the provider registry
- [ ] Test that o3-pro can be selected in auto mode for complex reasoning tasks
- [ ] Confirm temperature is correctly fixed at 1.0 for o3-pro
- [ ] Check that model validation accepts o3-pro as a valid model name