### PR TITLE
fix: remove unsupported sampling parameters for o-series models

### DIFF
--- a/simulator_tests/test_o3_model_selection.py
+++ b/simulator_tests/test_o3_model_selection.py
@@ -116,8 +116,26 @@ class O3ModelSelectionTest(BaseSimulatorTest):
 
             self.logger.info("  ✅ O3-mini model call completed")
 
-            # Test 3: Another tool with O3 to ensure it works across tools
-            self.logger.info("  3: Testing O3 with different tool (codereview)")
+            # Test 3: Explicit O3-pro model selection
+            self.logger.info("  3: Testing explicit O3-pro model selection")
+
+            response3, _ = self.call_mcp_tool(
+                "chat",
+                {
+                    "prompt": "Simple test: What is 4 + 4? Just give a brief answer.",
+                    "model": "o3-pro",
+                    "temperature": 1.0,  # O3-pro only supports default temperature of 1.0
+                },
+            )
+
+            if not response3:
+                self.logger.error("  ❌ O3-pro model test failed")
+                return False
+
+            self.logger.info("  ✅ O3-pro model call completed")
+
+            # Test 4: Another tool with O3 to ensure it works across tools
+            self.logger.info("  4: Testing O3 with different tool (codereview)")
 
             # Create a simple test file
             test_code = """def add(a, b):
@@ -128,7 +146,7 @@ def multiply(x, y):
 """
             test_file = self.create_additional_test_file("simple_math.py", test_code)
 
-            response3, _ = self.call_mcp_tool(
+            response4, _ = self.call_mcp_tool(
                 "codereview",
                 {
                     "files": [test_file],
@@ -138,14 +156,14 @@ def multiply(x, y):
                 },
             )
 
-            if not response3:
+            if not response4:
                 self.logger.error("  ❌ O3 with codereview tool failed")
                 return False
 
             self.logger.info("  ✅ O3 with codereview tool completed")
 
             # Validate model usage from server logs
-            self.logger.info("  4: Validating model usage in logs")
+            self.logger.info("  5: Validating model usage in logs")
             logs = self.get_recent_server_logs()
 
             # Check for OpenAI API calls (this proves O3 models are being used)
@@ -168,11 +186,11 @@ def multiply(x, y):
                 line for line in logs.split("\n") if "Sending request to openai API for codereview" in line
             ]
 
-            # Validation criteria - we expect 3 OpenAI calls (2 chat + 1 codereview)
-            openai_api_called = len(openai_api_logs) >= 3  # Should see 3 OpenAI API calls
-            openai_model_usage = len(openai_model_logs) >= 3  # Should see 3 model usage logs
-            openai_responses_received = len(openai_response_logs) >= 3  # Should see 3 responses
-            chat_calls_to_openai = len(chat_openai_logs) >= 2  # Should see 2 chat calls (o3 + o3-mini)
+            # Validation criteria - we expect 4 OpenAI calls (3 chat + 1 codereview)
+            openai_api_called = len(openai_api_logs) >= 4  # Should see 4 OpenAI API calls
+            openai_model_usage = len(openai_model_logs) >= 4  # Should see 4 model usage logs
+            openai_responses_received = len(openai_response_logs) >= 4  # Should see 4 responses
+            chat_calls_to_openai = len(chat_openai_logs) >= 3  # Should see 3 chat calls (o3 + o3-mini + o3-pro)
             codereview_calls_to_openai = len(codereview_openai_logs) >= 1  # Should see 1 codereview call
 
             self.logger.info(f"   OpenAI API call logs: {len(openai_api_logs)}")
@@ -263,8 +281,26 @@ def multiply(x, y):
 
             self.logger.info("  ✅ O3-mini model call via OpenRouter completed")
 
-            # Test 3: Codereview with O3 via OpenRouter
-            self.logger.info("  3: Testing O3 with codereview tool via OpenRouter")
+            # Test 3: O3-pro model via OpenRouter
+            self.logger.info("  3: Testing O3-pro model via OpenRouter")
+
+            response3, _ = self.call_mcp_tool(
+                "chat",
+                {
+                    "prompt": "Simple test: What is 4 + 4? Just give a brief answer.",
+                    "model": "o3-pro",
+                    "temperature": 1.0,
+                },
+            )
+
+            if not response3:
+                self.logger.error("  ❌ O3-pro model test via OpenRouter failed")
+                return False
+
+            self.logger.info("  ✅ O3-pro model call via OpenRouter completed")
+
+            # Test 4: Codereview with O3 via OpenRouter
+            self.logger.info("  4: Testing O3 with codereview tool via OpenRouter")
 
             test_code = """def add(a, b):
     return a + b
@@ -274,7 +310,7 @@ def multiply(x, y):
 """
             test_file = self.create_additional_test_file("simple_math.py", test_code)
 
-            response3, _ = self.call_mcp_tool(
+            response4, _ = self.call_mcp_tool(
                 "codereview",
                 {
                     "files": [test_file],
@@ -284,14 +320,14 @@ def multiply(x, y):
                 },
             )
 
-            if not response3:
+            if not response4:
                 self.logger.error("  ❌ O3 with codereview tool via OpenRouter failed")
                 return False
 
             self.logger.info("  ✅ O3 with codereview tool via OpenRouter completed")
 
             # Validate OpenRouter usage in logs
-            self.logger.info("  4: Validating OpenRouter usage in logs")
+            self.logger.info("  5: Validating OpenRouter usage in logs")
             logs = self.get_recent_server_logs()
 
             # Check for OpenRouter API calls
@@ -316,8 +352,8 @@ def multiply(x, y):
             self.logger.info(f"   OpenRouter response logs: {len(openrouter_response_logs)}")
 
             # Success criteria for OpenRouter
-            openrouter_used = len(openrouter_api_logs) >= 3 or len(openrouter_model_logs) >= 3
-            all_calls_succeeded = response1 and response2 and response3
+            openrouter_used = len(openrouter_api_logs) >= 4 or len(openrouter_model_logs) >= 4
+            all_calls_succeeded = response1 and response2 and response3 and response4
 
             success_criteria = [
                 ("All O3 model calls succeeded", all_calls_succeeded),


### PR DESCRIPTION
## Summary
- Fix o-series models (o3, o3-mini, o3-pro) failing due to unsupported sampling parameters
- Add comprehensive filtering for temperature, top_p, frequency_penalty, presence_penalty
- Ensure all o-series models work correctly with their API constraints

## Changes
1. **Core fix in `providers/openai.py`**:
   - Added `O_SERIES_MODELS` set to identify o-series models
   - Filter out unsupported sampling parameters before API calls
   - Force temperature=1.0 for o3 and o3-mini
   - Ensure o3-pro doesn't receive temperature in v1/responses API

2. **Updated tests**:
   - Modified existing tests to reflect that o-series models don't accept temperature
   - Added comprehensive test coverage for parameter filtering
   - Added o3-pro to integration test suite

## Test Results
- ✅ All unit tests pass
- ✅ O3 model integration test passes (including o3-pro)
- ✅ Real API calls verified working

## Context
This fix addresses the issue where o-series models would fail with "Unsupported parameter" errors when called with standard sampling parameters. All o-series models only support temperature=1.0 and reject other sampling parameters.